### PR TITLE
Added missing plugin.json

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -1,0 +1,81 @@
+{
+  "slug": "NonLinearInstruments",
+  "name": "NonLinearInstruments",
+  "version": "1.0.0",
+  "license": "GPL-3.0-or-later",
+  "brand": "NLnRi",
+  "author": "Ignasi Álvarez Garriga",
+  "authorEmail": "",
+  "authorUrl": "https://www.ignasialvarez.cat/",
+  "pluginUrl": "https://github.com/NonLinearInstruments/NLNRI_VCVRackPlugins",
+  "manualUrl": "https://github.com/NonLinearInstruments/NLNRI_VCVRackPlugins/blob/master/README.md",
+  "sourceUrl": "https://github.com/NonLinearInstruments/NLNRI_VCVRackPlugins",
+  "donateUrl": "",
+  "changelogUrl": "",
+  "modules": [
+    {
+      "slug": "QU4DiT",
+      "name": "QU4DiT",
+      "description": "Quadratic Iterator",
+      "tags": [
+        "Oscillator"
+      ]
+    },
+    {
+      "slug": "BallisticENV",
+      "name": "BallisticENV",
+      "description": "Ballistic ENV",
+      "tags": [
+        "Envelope generator"
+      ]
+    },
+    {
+      "slug": "LuciCell",
+      "name": "LuciCell",
+      "description": "Luci Cell",
+      "tags": [
+        "Oscillator"
+      ]
+    },
+    {
+      "slug": "Luci4AudioSum",
+      "name": "Luci4AudioSum",
+      "description": "Luci 4 Audio Sum",
+      "tags": [
+        "Mixer"
+      ]
+    },
+    {
+      "slug": "Luci4ParamDistr",
+      "name": "Luci4ParamDistr",
+      "description": "Luci 4 Param Distr",
+      "tags": [
+        "Multiple"
+      ]
+    },
+    {
+      "slug": "LuciControlRND",
+      "name": "LuciControlRND",
+      "description": "Luci Ctrl RAND",
+      "tags": [
+        "Controller"
+      ]
+    },
+    {
+      "slug": "LuciControlFREQ",
+      "name": "LuciControlFREQ",
+      "description": "Luci Ctrl FREQ",
+      "tags": [
+        "Controller"
+      ]
+    },
+    {
+      "slug": "LuciControlINFL",
+      "name": "LuciControlINFL",
+      "description": "Luci Ctrl INFLUENCE",
+      "tags": [
+        "Controller"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
@NonLinearInstruments Sorry, I didn't noticed that the `plugin.json` file (a new metadata descriptor needed for all v1 plugins) was missing from the previous pull-request set. I have just uploaded it into my fork, but I have to submit you a new PR. The only change is the addition of the `plugin.json` file, precisely.
Also, take a look at what I note about the plugin.json file in the last comment of the previous (now closed) PR: https://github.com/NonLinearInstruments/NLNRI_VCVRackPlugins/pull/14#issuecomment-642883516
Another thing to look at in the `plugin.json` file is the "License" field, you should choose your preferred licensing clause, in the VCVRack reference website you can find guidelines for details. I just filled in with the GPLv3 clause for now.